### PR TITLE
Fix for Aliasing the Facade Class Multiple Times

### DIFF
--- a/src/EnvSecurityServiceProvider.php
+++ b/src/EnvSecurityServiceProvider.php
@@ -42,7 +42,9 @@ class EnvSecurityServiceProvider extends ServiceProvider
         }
         $this->mergeConfigFrom($this->configPath, 'env-security');
 
-        class_alias(EnvSecurityFacade::class, \EnvSecurity::class);
+        if (!class_exists(\EnvSecurity::class)) {
+            class_alias(EnvSecurityFacade::class, \EnvSecurity::class);
+        }
     }
 
     public function boot()


### PR DESCRIPTION
This resolves the error:
```
In EnvSecurityServiceProvider.php line 46:

  Cannot declare class EnvSecurity, because the name is already in use
```