### PR TITLE
Adding driver for Google KMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ If you are using a version of Laravel earlier than 5.5, you will need to manuall
 ```
 
 ## Environment resolution
-In order for this package to decrypt the correct .env file when you deploy, you need to tell it how to figure out the environment. 
+In order for this package to decrypt the correct .env file when you deploy, you need to tell it how to figure out the environment.
 
 By default it will look for a `APP_ENV` environment variable. However you can provide your own custom resolver with a callback function. Put this in your `AppServiceProvider`'s `boot` method:
- 
+
 ```php
 \EnvSecurity::resolveEnvironmentUsing(function() {
     // return the environment name
 });
-``` 
+```
 
-This way you can resolve out the environment based on hostname, an EC2 instance tag, etc. This will then decrypt the correct .env file based on the environment name you return. 
+This way you can resolve out the environment based on hostname, an EC2 instance tag, etc. This will then decrypt the correct .env file based on the environment name you return.
 
 ## Drivers
 
@@ -67,13 +67,21 @@ Currently AWS Key Management Service is the only driver. (Others are planned for
 AWS KMS is a managed service that makes it easy for you to create and control the encryption keys used to encrypt your data, and uses FIPS 140-2 validated hardware security modules to protect the security of your keys.
 
 In the [AWS Console](https://console.aws.amazon.com/iam/home?#/encryptionKeys) create your encryption key. Make sure your AWS IAM user has `kms:Encrypt` and `kms:Decrypt` permissions on this key.
- 
-Copy the Key ID and store it as `AWS_KMS_KEY` in your local .env file. As you setup environment-specific .env files, make sure to include this `AWS_KMS_KEY` in each .env file. 
+
+Copy the Key ID and store it as `AWS_KMS_KEY` in your local .env file. As you setup environment-specific .env files, make sure to include this `AWS_KMS_KEY` in each .env file.
+
+### Google Cloud Key Management Service
+
+Google KMS securely manages encryption keys and secrets on Google Cloud Platform. The Google KMS integration with Google HSM makes it simple to create a key protected by a FIPS 140-2 Level 3 device.
+
+In the [Google Cloud Console](https://console.cloud.google.com/security/kms) create your key ring and key. Make sure your Google IAM user has the `Cloud KMS CryptoKey Encrypter/Decrypter` role for this key.
+
+Copy the Project, Key Ring and Key storing them as `GOOGLE_KMS_PROJECT`, `GOOGLE_KMS_KEY_RING` and `GOOGLE_KMS_KEY` in your local .env file. As you setup environment-specific .env files, make sure to include these keys in each .env file.
 
 ## Usage
 
 #### Create/edit a .env file
-Run `php artisan env:edit [name]` where `[name]` is the environment you wish to create or edit. This will open the file in `vi` for you to edit. Modify something 
+Run `php artisan env:edit [name]` where `[name]` is the environment you wish to create or edit. This will open the file in `vi` for you to edit. Modify something
 in the file, save, and quit.
 
 #### Decrypt your .env
@@ -84,13 +92,13 @@ If no environment `[name]` is provided, the environment will be determined by yo
 
 ## First deploy
 
-As you're reading through this, you're probably wondering how that *first initial* deploy is going to work. In order for this package to decrypt your .env config where all your sensitive credentials are stored, it needs AWS account access with permission to your KMS key. 
+As you're reading through this, you're probably wondering how that *first initial* deploy is going to work. In order for this package to decrypt your .env config where all your sensitive credentials are stored, it needs AWS account access with permission to your KMS key.
 
 Yep, it's [turtles all the way down](https://en.wikipedia.org/wiki/Turtles_all_the_way_down).
 
 There are a number of ways to handle this, all dependent on the environment and deployment process.
 
-1. If you are using AWS EC2, you can [assign IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html#roles-usingrole-ec2instance-roles) to grant the instance access to your KMS key. 
+1. If you are using AWS EC2, you can [assign IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html#roles-usingrole-ec2instance-roles) to grant the instance access to your KMS key.
 2. Regardless of your host provider, you can always put a `~/.aws/credentials` file on the server to provide necessary KMS permissions.
 3. Many deployment services like [Laravel Forge](https://forge.laravel.com/) or [Laravel Envoyer](https://envoyer.io/) provide ways to specify environment variables which you can use to provide AWS/KMS credentials.
-4. And of course, you can always just ssh in manually to a fresh new server and put the necessary AWS/KMS environment variables in a temporary .env file as well, which will get overwritten on the first deploy.   
+4. And of course, you can always just ssh in manually to a fresh new server and put the necessary AWS/KMS environment variables in a temporary .env file as well, which will get overwritten on the first deploy.

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "php": "^5.6|^7.0",
         "aws/aws-sdk-php": "^3.0",
-        "illuminate/support": "^5.0|^6.0"
+        "illuminate/support": "^5.0|^6.0",
+        "google/cloud-kms": "^1.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",

--- a/config/env-security.php
+++ b/config/env-security.php
@@ -35,6 +35,13 @@ return [
             'region' => env('AWS_KMS_REGION', env('AWS_REGION', 'us-east-1')),
         ],
 
+        'google_kms' => [
+            'project' => env('GOOGLE_KMS_PROJECT', env('GOOGLE_CLOUD_PROJECT')),
+            'location' => env('GOOGLE_KMS_LOCATION', 'global'),
+            'key_ring' => env('GOOGLE_KMS_KEY_RING'),
+            'key_id' => env('GOOGLE_KMS_KEY'),
+        ],
+
 //        'parameterstore' => [
 //
 //        ],

--- a/src/Drivers/GoogleKmsDriver.php
+++ b/src/Drivers/GoogleKmsDriver.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace STS\EnvSecurity\Drivers;
+
+use Google\Cloud\Kms\V1\KeyManagementServiceClient;
+use Illuminate\Contracts\Encryption\Encrypter;
+
+/**
+ * Class GoogleKmsDriver
+ * @package STS\EnvSecurity\Drivers
+ */
+class GoogleKmsDriver implements Encrypter
+{
+    /**
+     * @var KeyManagementServiceClient
+     */
+    protected $client;
+
+    /**
+     * @var string
+     */
+    protected $keyName;
+
+    /**
+     * KmsDriver constructor.
+     *
+     * @param KeyManagementServiceClient $client
+     * @param string $project
+     * @param string $location
+     * @param string $keyRing
+     * @param string $key
+     */
+    public function __construct(KeyManagementServiceClient $client, $project, $location, $keyRing, $key)
+    {
+        $this->client = $client;
+        $this->keyName = $client::cryptoKeyName($project, $location, $keyRing, $key);
+    }
+
+    /**
+     * @param string $value
+     * @param bool   $serialize
+     *
+     * @return mixed|string
+     */
+    public function encrypt($value, $serialize = true)
+    {
+        $result = $this->client->encrypt($this->keyName, $value)->getCiphertext();
+
+        return ($serialize)
+            ? base64_encode($result)
+            : $result;
+    }
+
+    /**
+     * @param string $payload
+     * @param bool   $unserialize
+     *
+     * @return string
+     */
+    public function decrypt($payload, $unserialize = true)
+    {
+        if ($unserialize) {
+            $payload = base64_decode($payload);
+        }
+
+        return $this->client->decrypt($this->keyName, $payload)->getPlaintext();
+    }
+}

--- a/src/EnvSecurityManager.php
+++ b/src/EnvSecurityManager.php
@@ -97,7 +97,7 @@ class EnvSecurityManager extends Manager
             Arr::get($config, 'project'),
             Arr::get($config, 'location'),
             Arr::get($config, 'key_ring'),
-            Arr::get($config, 'key_id'),
+            Arr::get($config, 'key_id')
         );
     }
 }

--- a/src/EnvSecurityManager.php
+++ b/src/EnvSecurityManager.php
@@ -3,7 +3,10 @@
 namespace STS\EnvSecurity;
 
 use Aws\Kms\KmsClient;
+use Google\Cloud\Kms\V1\KeyManagementServiceClient;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Manager;
+use STS\EnvSecurity\Drivers\GoogleKmsDriver;
 use STS\EnvSecurity\Drivers\KmsDriver;
 
 class EnvSecurityManager extends Manager
@@ -74,5 +77,27 @@ class EnvSecurityManager extends Manager
             : $config['key_id'];
 
         return new KmsDriver(new KmsClient($config), $key);
+    }
+
+    /**
+     * @return GoogleKmsDriver
+     */
+    public function createGoogleKmsDriver()
+    {
+        $config = $this->app['config']['env-security.drivers.google_kms'];
+
+        if ($this->keyResolver) {
+            $config['key_id'] = $this->resolveKey();
+        }
+
+        $options = Arr::get($config, 'options', []);
+
+        return new GoogleKmsDriver(
+            new KeyManagementServiceClient($options),
+            Arr::get($config, 'project'),
+            Arr::get($config, 'location'),
+            Arr::get($config, 'key_ring'),
+            Arr::get($config, 'key_id'),
+        );
     }
 }

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use Config;
 use EnvSecurity;
+use STS\EnvSecurity\Drivers\GoogleKmsDriver;
 use STS\EnvSecurity\Drivers\KmsDriver;
 
 class ManagerTest extends TestCase
@@ -12,6 +13,16 @@ class ManagerTest extends TestCase
     {
         Config::set('env-security.default', 'kms');
         $this->assertInstanceOf(KmsDriver::class, EnvSecurity::driver());
+
+        Config::set('env-security.default', 'google_kms');
+        Config::set('env-security.drivers.google_kms', [
+            'project' => 'project-131708',
+            'location' => 'global',
+            'key_ring' => 'laravel',
+            'key_id' => 'dotenv',
+        ]);
+
+        $this->assertInstanceOf(GoogleKmsDriver::class, EnvSecurity::driver());
 
         Config::set('env-security.default', 'invalid');
 


### PR DESCRIPTION
In the [Google Cloud Console](https://console.cloud.google.com/security/kms) create your key ring and key. Make sure your Google IAM user has the `Cloud KMS CryptoKey Encrypter/Decrypter` role for this key.

Copy the Project, Key Ring and Key storing them as `GOOGLE_KMS_PROJECT`, `GOOGLE_KMS_KEY_RING` and `GOOGLE_KMS_KEY` in your local .env file.