### PR TITLE
Adding environment to function

### DIFF
--- a/src/Console/Edit.php
+++ b/src/Console/Edit.php
@@ -111,7 +111,7 @@ class Edit extends Command
     protected function saveEnvContents($plaintext)
     {
         $ciphertext = !empty($plaintext)
-            ? $this->envSecurity->encrypt($plaintext)
+            ? $this->envSecurity->setEnvironment($this->environment())->encrypt($plaintext)
             : '';
 
         $this->saveEncrypted($ciphertext, $this->environment());


### PR DESCRIPTION
I noticed an issue when using the edit command. When the env file does not exist it was defaulting to the default env file no matter what the $environment variable was set to in the edit command. 

After adding the setEnvironment function this issue resolved. 