### PR TITLE
Console\Edit: set environment even when initializing new file

### DIFF
--- a/src/Console/Edit.php
+++ b/src/Console/Edit.php
@@ -56,6 +56,8 @@ class Edit extends Command
      */
     public function handle()
     {
+        $this->envSecurity->setEnvironment($this->environment());
+
         $this->saveEnvContents(
             $this->edit(
                 $this->loadEnvContents()
@@ -104,7 +106,7 @@ class Edit extends Command
     protected function loadEnvContents()
     {
         if($ciphertext = $this->loadEncrypted($this->environment())) {
-            return $this->envSecurity->setEnvironment($this->environment())->decrypt($ciphertext);
+            return $this->envSecurity->decrypt($ciphertext);
         }
 
         return '';


### PR DESCRIPTION
Ensure that the environment specified by the user when issuing the `env:edit` command is respected whether or not the environment file is being created anew.

Fixes #20.