### PR TITLE
EnvSecurityManager: use non-deprecated form...

### DIFF
--- a/src/EnvSecurityManager.php
+++ b/src/EnvSecurityManager.php
@@ -146,7 +146,7 @@ class EnvSecurityManager extends Manager
                 throw new RuntimeException('Failed to compress the content.');
             }
 
-            $value = "gzencoded::${compressed}";
+            $value = "gzencoded::{$compressed}";
         }
         // Encode Value
         return $this->driver()->encrypt($value, $serialize);


### PR DESCRIPTION
...of string interpolation.

Fixes #26.